### PR TITLE
Remove no-clobber from wget when downloading from earthdata

### DIFF
--- a/src/spark/gedi_download_pipeline.py
+++ b/src/spark/gedi_download_pipeline.py
@@ -130,10 +130,9 @@ def _download_url(product, input):
     outfile_path = constants.gedi_product_path(product) / name
     if os.path.exists(outfile_path):
         return outfile_path
-    try:
-        temp = tempfile.NamedTemporaryFile(
-            dir=constants.gedi_product_path(product)
-        )
+    with tempfile.NamedTemporaryFile(
+        dir=constants.gedi_product_path(product)
+    ) as temp:
         subprocess.run(
             [
                 "wget",
@@ -151,11 +150,6 @@ def _download_url(product, input):
             check=True,
         )
         shutil.move(temp.name, outfile_path)
-    finally:
-        try:
-            temp.close()
-        except:
-            pass
     return outfile_path
 
 

--- a/src/spark/gedi_download_pipeline.py
+++ b/src/spark/gedi_download_pipeline.py
@@ -144,7 +144,6 @@ def _download_url(product, input):
                 "--auth-no-challenge=on",
                 "--keep-session-cookies",
                 "--content-disposition",
-                "-nc",
                 "-O",
                 temp.name,
                 url,


### PR DESCRIPTION
This line makes no sense to me, but clearly must have worked at some point? The bug this fixes is:

* A temporary file is created on disk using NamedTemporaryFile
* Wget is told to fetch data into that file
* wget is told where to write the file using -O, and is also told not to clobber the file with -nc

If you have both -O and -nc, and the target file exists, wget will not download the data, and just fail. 

The fix is just to remove the -nc - we're writing to a temporary file, so it doesn't matter that we're clobbering.