### PR TITLE
Remove tempdir prefix

### DIFF
--- a/src/utils/unzip.py
+++ b/src/utils/unzip.py
@@ -71,7 +71,7 @@ def unzip(
             else:
                 # To create a file at a certain out path, first extract to
                 # temporary directory and then move to desired out path
-                with tempfile.TemporaryDirectory(prefix=str(out_path) + "/") as tmp_dir:
+                with tempfile.TemporaryDirectory() as tmp_dir:
                     logger.debug("Temporary dir: %s", tmp_dir)
                     tmp_path = pathlib.Path(tmp_dir)
                     zip_archive.extract(compressed_file, path=tmp_path)


### PR DESCRIPTION
Hey Amelia,

Thanks so much for the library, it's making things much easier for us (also sorry for the numerous PRs we're opening). When extracting the zipped data I was seeing errors with creating the temporary directory. I think this is because there was a `/` being added to the prefix for the name of the temporary directory which meant there was actually two levels of directory hierarchy and the first was never `mkdir`-ed so it was failing. If the output zip directory is nested at all (e.g. `./out/tif`) I think this will always fail.

This PR removes the prefix entirely as it's not strictly necessary beyond wanting to easily find out what a temporary directory was used for (happy to change this PR to add a prefix that doesn't contain file path separators if that's desired).