### PR TITLE
Split constants.py into constants and environment/side effects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The above diagram shows an overflow of the steps taken to generate the results. 
 Fork this repository, create a new python environment, and install the project requirements, including python packages in `requirements/requirements.txt`.
 
 Set appropriate environment variables:
-Change `src/constants.py` to contain the database location and password for your database. Set the file paths to appropriate values.
+Change `src/environment.py` to contain the database location and password for your database. Set the file paths to appropriate values.
 Create a file called `.env` in your home directory with the following format:
 
 ```python

--- a/notebooks/28-ah2174-gedi-recovery-figures.ipynb
+++ b/notebooks/28-ah2174-gedi-recovery-figures.ipynb
@@ -42,7 +42,7 @@
     "import skgstat as skg\n",
     "from pylr2 import regress2\n",
     "\n",
-    "from src import constants\n"
+    "from src import environment\n"
    ]
   },
   {
@@ -139,7 +139,7 @@
     "# Add the JRC raster tiles\n",
     "# N.b. This takes about 35 seconds per file to plot with 0.02 degree pixels\n",
     "# Increase 'spacing' for faster plotting at lower resolution\n",
-    "files = [ f.as_posix() for f in (constants.JRC_PATH / \"AnnualChange\" / \"tifs\").glob(\"*2021_SAM*_[NS][01]*.tif\") ]\n",
+    "files = [ f.as_posix() for f in (environment.JRC_PATH / \"AnnualChange\" / \"tifs\").glob(\"*2021_SAM*_[NS][01]*.tif\") ]\n",
     "for f in files:\n",
     "    plot_dem(f, ax)\n",
     "\n",

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,13 +1,5 @@
 """Module contains all project wide constants."""
-import logging
-import os
-from pathlib import Path
 from enum import Enum
-
-import dotenv
-
-dotenv.load_dotenv()
-
 
 class GediProduct(Enum):
     L1B = "level1B"
@@ -17,50 +9,6 @@ class GediProduct(Enum):
     L4A = "level4A"
     L4B = "level4B"
 
-
-# ---------------- PATH CONSTANTS -------------------
-#  Source folder path
-constants_path = Path(__file__)
-SRC_PATH = constants_path.parent
-PROJECT_PATH = SRC_PATH.parent
-CONDA_ENV = os.getenv("CONDA_DEFAULT_ENV")
-
-# Log relatedd paths
-LOG_PATH = PROJECT_PATH / "logs"
-LOG_PATH.mkdir(parents=True, exist_ok=True)
-
-#  Data related paths
-DATA_PATH = Path(os.getenv("DATA_PATH"))
-USER_PATH = Path(os.getenv("USER_PATH"))
-EARTHDATA_USER = os.getenv("EARTHDATA_USER")
-EARTHDATA_PASSWORD = os.getenv("EARTHDATA_PASSWORD")
-EARTH_DATA_COOKIE_FILE = Path(os.getenv("EARTH_DATA_COOKIE_FILE"))
-
-GEDI_PATH = DATA_PATH / "GEDI"
-
-
-def gedi_product_path(product):
-    return GEDI_PATH / product.value
-
-
-GEDI_L1B_PATH = gedi_product_path(GediProduct.L1B)
-GEDI_L2A_PATH = gedi_product_path(GediProduct.L2A)
-GEDI_L4A_PATH = gedi_product_path(GediProduct.L4A)
-JRC_PATH = DATA_PATH / "JRC"
-ENV_VARS_PATH = DATA_PATH / "EnvVars"
-
-ENV_VARS_NAMES = ["defMean", "SCCsoil", "fpar", "lightning", "srtm"]
-
-
-# ---------------- LOGGING CONSTANTS ----------------
-DEFAULT_FORMATTER = logging.Formatter(
-    (
-        "%(asctime)s %(levelname)s: %(message)s "
-        "[in %(funcName)s at %(pathname)s:%(lineno)d]"
-    )
-)
-DEFAULT_LOG_FILE = LOG_PATH / "default_log.log"
-DEFAULT_LOG_LEVEL = logging.INFO  # verbose logging per default
 
 # ---------------- PROJECT CONSTANTS ----------------
 # Coordinate reference systems (crs)
@@ -83,14 +31,3 @@ SIRGAS2000_UTM21S = "EPSG:31981"  # https://epsg.io/31981
 SIRGAS2000_UTM22S = "EPSG:31982"  # https://epsg.io/31982
 SIRGAS2000_UTM23S = "EPSG:31983"  # https://epsg.io/31983
 SIRGAS2000_UTM24S = "EPSG:31984"  # https://epsg.io/31984
-
-# ---------------- DATABASE CONSTANTS ----------------
-DB_HOST = os.getenv("DB_HOST")  # JASMIN database server
-DB_PORT = "5432"
-DB_NAME = os.getenv("DB_NAME")  # Database for GEDI shots
-DB_USER = os.getenv("DB_USER")
-DB_PASSWORD = os.getenv("DB_PASSWORD")
-DB_POSTGRES = "postgresql"
-DB_CONFIG = (
-    f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
-)

--- a/src/data/gedi_database.py
+++ b/src/data/gedi_database.py
@@ -8,7 +8,8 @@ import pyproj
 import sqlalchemy as db
 from sqlalchemy import create_engine, inspect
 
-from src.constants import DB_CONFIG, WGS84
+from src.constants import WGS84
+from src.environment import DB_CONFIG
 from src.utils.logging_util import get_logger
 
 import warnings

--- a/src/data/gedi_database_loader.py
+++ b/src/data/gedi_database_loader.py
@@ -12,7 +12,8 @@ from sqlalchemy.sql.schema import Table
 import warnings
 from src.data.gedi_granule import GediGranule
 from src.utils import logging_util
-from src.constants import WGS84, DB_CONFIG
+from src.constants import WGS84
+from src.environment import DB_CONFIG
 
 logger = logging_util.get_logger("data_logger", INFO)
 

--- a/src/data/jrc_download.py
+++ b/src/data/jrc_download.py
@@ -10,7 +10,7 @@ import subprocess
 import psutil
 import requests
 
-from src.constants import DATA_PATH
+from src.environment import DATA_PATH
 from src.utils.logging_util import get_logger
 
 logger = get_logger(__name__)

--- a/src/data/jrc_loading.py
+++ b/src/data/jrc_loading.py
@@ -8,7 +8,7 @@ import rioxarray as rxr
 import xarray as xr
 from tqdm.autonotebook import tqdm
 
-from src.constants import JRC_PATH
+from src.environment import JRC_PATH
 from src.utils.logging_util import get_logger
 from src.utils.os import list_content
 

--- a/src/environment.py
+++ b/src/environment.py
@@ -1,0 +1,65 @@
+import logging
+import os
+from pathlib import Path
+
+import dotenv
+
+from .constants import GediProduct
+
+dotenv.load_dotenv()
+
+# ---------------- PATH CONSTANTS -------------------
+#  Source folder path
+constants_path = Path(__file__)
+SRC_PATH = constants_path.parent
+PROJECT_PATH = SRC_PATH.parent
+CONDA_ENV = os.getenv("CONDA_DEFAULT_ENV")
+
+# Log relatedd paths
+LOG_PATH = PROJECT_PATH / "logs"
+LOG_PATH.mkdir(parents=True, exist_ok=True)
+
+#  Data related paths
+DATA_PATH = Path(os.getenv("DATA_PATH"))
+USER_PATH = Path(os.getenv("USER_PATH"))
+EARTHDATA_USER = os.getenv("EARTHDATA_USER")
+EARTHDATA_PASSWORD = os.getenv("EARTHDATA_PASSWORD")
+EARTH_DATA_COOKIE_FILE = Path(os.getenv("EARTH_DATA_COOKIE_FILE"))
+
+GEDI_PATH = DATA_PATH / "GEDI"
+
+
+def gedi_product_path(product):
+	return GEDI_PATH / product.value
+
+
+GEDI_L1B_PATH = gedi_product_path(GediProduct.L1B)
+GEDI_L2A_PATH = gedi_product_path(GediProduct.L2A)
+GEDI_L4A_PATH = gedi_product_path(GediProduct.L4A)
+JRC_PATH = DATA_PATH / "JRC"
+ENV_VARS_PATH = DATA_PATH / "EnvVars"
+
+ENV_VARS_NAMES = ["defMean", "SCCsoil", "fpar", "lightning", "srtm"]
+
+
+# ---------------- LOGGING CONSTANTS ----------------
+DEFAULT_FORMATTER = logging.Formatter(
+	(
+		"%(asctime)s %(levelname)s: %(message)s "
+		"[in %(funcName)s at %(pathname)s:%(lineno)d]"
+	)
+)
+DEFAULT_LOG_FILE = LOG_PATH / "default_log.log"
+DEFAULT_LOG_LEVEL = logging.INFO  # verbose logging per default
+
+
+# ---------------- DATABASE CONSTANTS ----------------
+DB_HOST = os.getenv("DB_HOST")  # JASMIN database server
+DB_PORT = "5432"
+DB_NAME = os.getenv("DB_NAME")  # Database for GEDI shots
+DB_USER = os.getenv("DB_USER")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+DB_POSTGRES = "postgresql"
+DB_CONFIG = (
+	f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+)

--- a/src/processing/env_vars_processing.py
+++ b/src/processing/env_vars_processing.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pathlib
 import rioxarray as rxr
 
-from src.constants import ENV_VARS_PATH
+from src.environment import ENV_VARS_PATH
 from src.utils.logging import get_logger
 
 logger = get_logger(__file__)
@@ -28,7 +28,7 @@ def main(
 ):
     if not outdir.exists():
         raise FileNotFoundError(f'Could not find specified outdir {outdir}')
-    
+
     if (outdir / 'gedi_envlayers.feather').exists() and not overwrite:
         print(f'Outfile {outdir}/gedi_envlayers.feather already exists and overwrite set to false, returning')
         return 1
@@ -38,7 +38,7 @@ def main(
 
     if not layerdir.exists():
         raise FileNotFoundError(f'Could not find specified layerdir {layerdir}')
-    
+
     layers = layerdir.glob('*.tif')
 
     gedi = pd.read_feather(gedifile)
@@ -71,7 +71,7 @@ if __name__ == '__main__':
        "-g",
         "--gedifile",
         help="The path to the feather file containing GEDI shots for overlay.",
-        type=str, 
+        type=str,
     )
     parser.add_argument(
         "-l",

--- a/src/processing/jrc_processing.py
+++ b/src/processing/jrc_processing.py
@@ -10,7 +10,7 @@ import rioxarray as rxr
 import xarray as xr
 from tqdm.autonotebook import tqdm
 
-from src.constants import JRC_PATH
+from src.environment import JRC_PATH
 from src.utils.logging_util import get_logger
 
 logger = get_logger(__file__)

--- a/src/utils/logging_util.py
+++ b/src/utils/logging_util.py
@@ -4,7 +4,7 @@ import os
 import sys
 from logging.handlers import TimedRotatingFileHandler
 
-from src.constants import DEFAULT_FORMATTER, DEFAULT_LOG_FILE, DEFAULT_LOG_LEVEL
+from src.environment import DEFAULT_FORMATTER, DEFAULT_LOG_FILE, DEFAULT_LOG_LEVEL
 
 
 def get_console_handler(


### PR DESCRIPTION
I needed to use the GediProducts enum type in some unit tests on the 4C TMF pipeline, but I hit the issue that:

* constants.py would thrown an exception if you did have certain  environment variables set
* it makes directories as a direct result of importing it

so I've split the file into two - one is pure constants, and the other is settings about the current environment.