### PR TITLE
Refactor out shape validation to be more generically useful

### DIFF
--- a/src/data/gedi_download_pipeline.py
+++ b/src/data/gedi_download_pipeline.py
@@ -1,120 +1,31 @@
-"""Script to download GEDI order multithreaded"""
-import argparse
-import concurrent
-import os
-import subprocess
-from typing import Union
+from geopandas import gpd
+from shapely.geometry.polygon import orient
+from shapely.geometry import box
 
-from tqdm.autonotebook import tqdm
+class DetailError(Exception):
+    """Used when too many points in a shape for NASA's API"""
 
-from src.utils.logging import get_logger
+def check_and_format_shape(shp: gpd.GeoDataFrame, simplify: bool = False) -> gpd.GeoSeries:
+    if len(shp) > 1:
+        raise ValueError("Only one polygon at a time supported.")
+    row = shp.geometry.values[0]
+    multi = row.geom_type.startswith("Multi")
+    oriented = None
 
-logger = get_logger(__file__)
+    # The CMR API cannot accept a shapefile with more than 5000 points,
+    # so we offer to simplify the query to just the bounding box around the region.
+    if multi:
+        n_coords = sum([len(part.exterior.coords) for part in row.geoms])
+    else:
+        n_coords = len(row.exterior.coords)
+    if n_coords > 4999:
+        if not simplify:
+            raise DetailError("Too many coords")
+        oriented = gpd.GeoSeries(box(*row.bounds))
 
+    if multi and oriented is None:
+        oriented = gpd.GeoSeries([orient(s) for s in row.geoms])
+    if not multi and oriented is None:
+        oriented = gpd.GeoSeries(orient(row))
 
-def _generate_link(order_number: Union[str, int], zip_number: Union[str, int]) -> str:
-    return f"https://e4ftl01.cr.usgs.gov/ops/esir/{order_number}.zip?{zip_number}"
-
-
-def _wget(link: str) -> bool:
-    try:
-        subprocess.call(["wget", link])
-        return True
-    except Exception as e:  # pylint: disable=broad-except
-        logger.exception(e)
-        print(e)
-        return False
-
-
-def download_gedi_order(
-    order_number: Union[str, int], n_zips: int, max_threads: int, save_dir: os.PathLike
-) -> dict[str, bool]:
-    """
-    Download all zips for a GEDI order with given `order_number` and save them to
-    save_dir.
-
-    Args:
-        order_number (Union[str, int]): The order number of the order to download
-        n_zips (int): The number of zip files in the order
-        max_threads (int): The maximum number of threads to be used during download
-        save_dir (os.PathLike): The path to save the downloads under.
-
-    Returns:
-        dict[str, bool]: A dictionary where the key is the download link to the order
-            and the value is whether the download was successful or not.
-    """
-
-    # change working directory
-    os.makedirs(save_dir, exist_ok=True)
-    os.chdir(save_dir)
-
-    # set up all links to download
-    links = [
-        _generate_link(order_number, zip_number) for zip_number in range(1, n_zips + 1)
-    ]
-    results = {}
-
-    with concurrent.futures.ThreadPoolExecutor(
-        max_workers=max_threads, thread_name_prefix=f"Order_{order_number}"
-    ) as executor:
-        futures = {executor.submit(_wget, link): link for link in links}
-
-        for future in tqdm(concurrent.futures.as_completed(futures), total=len(links)):
-            try:
-                name = futures[future]
-                was_successful = future.result()
-                print(f"{name} successful: {was_successful}")
-                logger.info("%s successful: %s", name, was_successful)
-                results[name] = was_successful
-            except Exception as e:  # pylint: disable=broad-except
-                logger.exception(e)
-                print(e)
-
-    return results
-
-
-if __name__ == "__main__":
-    # Parse command line arguments
-    parser = argparse.ArgumentParser(description="GEDI order download script")
-    parser.add_argument(
-        "order_number",
-        help="The number of the order to download",
-        type=int,
-    )
-    parser.add_argument(
-        "n_zips",
-        help="The number of zip files in the order",
-        type=int,
-    )
-    parser.add_argument(
-        "max_threads",
-        help="The maximum number of threads to use for the download",
-        type=int,
-        default=10,
-        nargs="?",  # Argument is optional
-    )
-    parser.add_argument(
-        "save_path",
-        help="The folder in which to save the downloaded files.",
-        type=str,
-    )
-    parser.add_argument(
-        "-o",
-        "--overwrite",
-        help=(
-            "If True, existing files are downloaded again and overwritten. "
-            "Defaults to False."
-        ),
-        type=bool,
-        default=False,
-        nargs="?",  # Argument is optional
-    )
-
-    args = parser.parse_args()
-
-    download_gedi_order(
-        order_number=args.order_number,
-        n_zips=args.n_zips,
-        max_threads=args.max_threads,
-        save_dir=args.save_path,
-    )
+    return oriented

--- a/src/data/gedi_download_pipeline.py
+++ b/src/data/gedi_download_pipeline.py
@@ -4,6 +4,8 @@ from shapely.geometry import box
 
 class DetailError(Exception):
     """Used when too many points in a shape for NASA's API"""
+    def __init__(self, n_coords: int):
+        self.n_coords = n_coords
 
 def check_and_format_shape(shp: gpd.GeoDataFrame, simplify: bool = False) -> gpd.GeoSeries:
     if len(shp) > 1:
@@ -20,7 +22,7 @@ def check_and_format_shape(shp: gpd.GeoDataFrame, simplify: bool = False) -> gpd
         n_coords = len(row.exterior.coords)
     if n_coords > 4999:
         if not simplify:
-            raise DetailError("Too many coords")
+            raise DetailError(n_coords)
         oriented = gpd.GeoSeries(box(*row.bounds))
 
     if multi and oriented is None:

--- a/src/spark/gedi_download_pipeline.py
+++ b/src/spark/gedi_download_pipeline.py
@@ -295,14 +295,14 @@ if __name__ == "__main__":
     try:
         try:
             shp = check_and_format_shape(shp)
-        except DetailError:
+        except DetailError as exc:
             input(
                 (
                     "The NASA API can only accept up to 5000 vertices in a single shape,\n"
                     "but the shape you supplied has {} vertices.\n"
                     "If you would like to automatically simplify this shape to its\n"
                     "bounding box, press ENTER, otherwise Ctrl-C to quit."
-                ).format(n_coords)
+                ).format(exc.n_coords)
             )
             shp = check_and_format_shape(shp, simplify=True)
     except ValueError:

--- a/tests/data/test_inputs.py
+++ b/tests/data/test_inputs.py
@@ -65,4 +65,4 @@ def test_too_many_points_simplify():
 	geometry = gpd.GeoSeries(polygon)
 
 	checked = check_and_format_shape(geometry, simplify=True)
-	assert checked is not None
+	checked.contains(geometry)

--- a/tests/data/test_inputs.py
+++ b/tests/data/test_inputs.py
@@ -1,0 +1,68 @@
+import tempfile
+
+import pytest
+from geopandas import gpd
+from shapely import MultiPolygon, Polygon
+
+from src.data.gedi_download_pipeline import check_and_format_shape, DetailError
+
+def _make_polygon(lat: float, lng: float, radius: float) -> Polygon:
+	origin_lat = lat + radius
+	origin_lng = lng - radius
+	far_lat = lat - radius
+	far_lng = lng + radius
+
+	return Polygon([
+		[origin_lng, origin_lat],
+		[far_lng,    origin_lat],
+		[far_lng,    far_lat],
+		[origin_lng, far_lat],
+		[origin_lng, origin_lat],
+	])
+
+def test_simple_shape():
+
+	polygon = _make_polygon(10.0, 10.0, 0.3)
+	geometry = gpd.GeoSeries(polygon)
+
+	checked = check_and_format_shape(geometry)
+	assert checked is not None
+
+def test_too_many_shapes():
+
+	polygon1 = _make_polygon(10.0, 10.0, 0.3)
+	polygon2 = _make_polygon(12.0, 12.0, 0.4)
+	geometry = gpd.GeoSeries([polygon1, polygon2])
+
+	with pytest.raises(ValueError):
+		_ = check_and_format_shape(geometry)
+
+def test_multi_polygon_shapes():
+
+	polygon1 = _make_polygon(10.0, 10.0, 0.3)
+	polygon2 = _make_polygon(12.0, 12.0, 0.4)
+	multipolygon = MultiPolygon([polygon1, polygon2])
+	geometry = gpd.GeoSeries(multipolygon)
+
+	checked = check_and_format_shape(geometry)
+	assert checked is not None
+
+def test_too_many_points_dont_simplify():
+	points = []
+	for i in range(5001):
+		points.append((0.1, 0.0001 * i))
+	polygon = Polygon(points)
+	geometry = gpd.GeoSeries(polygon)
+
+	with pytest.raises(DetailError):
+		_ = check_and_format_shape(geometry)
+
+def test_too_many_points_simplify():
+	points = []
+	for i in range(5001):
+		points.append((0.1, 0.0001 * i))
+	polygon = Polygon(points)
+	geometry = gpd.GeoSeries(polygon)
+
+	checked = check_and_format_shape(geometry, simplify=True)
+	assert checked is not None

--- a/tests/data/test_inputs.py
+++ b/tests/data/test_inputs.py
@@ -1,3 +1,4 @@
+import math
 import tempfile
 
 import pytest
@@ -50,7 +51,8 @@ def test_multi_polygon_shapes():
 def test_too_many_points_dont_simplify():
 	points = []
 	for i in range(5001):
-		points.append((0.1, 0.0001 * i))
+		angle = math.pi / (2 * 5001)
+		points.append((math.sin(angle), math.cos(angle)))
 	polygon = Polygon(points)
 	geometry = gpd.GeoSeries(polygon)
 
@@ -60,9 +62,10 @@ def test_too_many_points_dont_simplify():
 def test_too_many_points_simplify():
 	points = []
 	for i in range(5001):
-		points.append((0.1, 0.0001 * i))
+		angle = (math.pi / (2 * 5001)) * i
+		points.append((math.sin(angle), math.cos(angle)))
 	polygon = Polygon(points)
 	geometry = gpd.GeoSeries(polygon)
 
 	checked = check_and_format_shape(geometry, simplify=True)
-	checked.contains(geometry)
+	assert checked.contains(geometry).all()


### PR DESCRIPTION
I needed to have the check_and_format_shape method be accessible from other code, so I moved it to `data/gedi_download_pipeline.py` and removed other code as discussed. Over time I'll add more there  I suspect.

I also added some tests, as I needed to remove side-effects from the function and keep them in the original file, and I wanted some confidence I hadn't broken too much.