### PR TITLE
Don't assume all zips have a base folder

### DIFF
--- a/src/utils/unzip.py
+++ b/src/utils/unzip.py
@@ -54,7 +54,7 @@ def unzip(
         for compressed_file in files_progress:
             # Get relative path of file in zip archive
             if remove_archive_name:
-                relative_path = compressed_file.filename.split("/", maxsplit=1)[1]
+                relative_path = compressed_file.filename.split("/", maxsplit=1)[-1]
             else:
                 relative_path = compressed_file.filename
 


### PR DESCRIPTION
I was using this function on other downloads (in this case the RESOLVE ecoregion zips) and this fixes that case where there is no base folder.