### PR TITLE
Make number of coords optional

### DIFF
--- a/biomassrecovery/data/gedi_download_pipeline.py
+++ b/biomassrecovery/data/gedi_download_pipeline.py
@@ -7,9 +7,27 @@ class DetailError(Exception):
     def __init__(self, n_coords: int):
         self.n_coords = n_coords
 
-def check_and_format_shape(shp: gpd.GeoDataFrame, simplify: bool = False) -> gpd.GeoSeries:
+def check_and_format_shape(shp: gpd.GeoDataFrame, simplify: bool = False, max_coords: int = 4999) -> gpd.GeoSeries:
+    """
+    Checks a shape for compatibility with NASA's API.
+
+    Args:
+        shp (gpd.GeoDataFrame): The shape to check and format.
+        simplify (bool): Whether to simplify the shape if it doesn't meet the max_coords threshold.
+        max_coords (int): Threshold for simplifying, must be less than 5000 (NASA's upper-bound).
+
+    Raises:
+        ValueError: If max_coords is not less than 5000 or more than one polygon is supplied.
+        DetailError: If simplify is not true and the shape does not have less than max_coord points.
+
+    Returns:
+        GeoSeries: The possibly simplified shape.
+    """
     if len(shp) > 1:
         raise ValueError("Only one polygon at a time supported.")
+    if max_coords > 4999:
+        raise ValueError("NASA's API can only cope with less than 5000 points")
+
     row = shp.geometry.values[0]
     multi = row.geom_type.startswith("Multi")
     oriented = None
@@ -20,7 +38,7 @@ def check_and_format_shape(shp: gpd.GeoDataFrame, simplify: bool = False) -> gpd
         n_coords = sum([len(part.exterior.coords) for part in row.geoms])
     else:
         n_coords = len(row.exterior.coords)
-    if n_coords > 4999:
+    if n_coords > max_coords:
         if not simplify:
             raise DetailError(n_coords)
         oriented = gpd.GeoSeries(box(*row.bounds))


### PR DESCRIPTION
I explained the reasoning a little bit in the comment but essentially over in the TMF work I think we've hit the fourth limit of the NASA API:

> Shapefile geometries with precision greater than 7 significant digits should ensure their points are at least 1 meter apart

I think trying to calculate if this is the case for each shape is a bit much and probably involves some projection gymnastics. Also dropping the significant digits doesn't help much because the API just told me that things were too close. This lead me to this option which is to proxy all of this by lowering the `max_coords` value that is used to know when to simplify or not. For our work, we can set this a good bit lower and take the hit of downloading a bit more data than we need. 