### PR TITLE
Make LOG_PATH configurable from environment variable

### DIFF
--- a/biomassrecovery/environment.py
+++ b/biomassrecovery/environment.py
@@ -16,7 +16,10 @@ PROJECT_PATH = SRC_PATH.parent
 CONDA_ENV = os.getenv("CONDA_DEFAULT_ENV")
 
 # Log relatedd paths
-LOG_PATH = PROJECT_PATH / "logs"
+try:
+	LOG_PATH = Path(os.getenv("LOG_PATH"))
+except TypeError:
+	LOG_PATH = PROJECT_PATH / "logs"
 LOG_PATH.mkdir(parents=True, exist_ok=True)
 
 #  Data related paths


### PR DESCRIPTION
Allows you to specify LOG_PATH in the environment to override the default, addressing #14. 

I think the default behaviour probably needs changed, but I needed a workaround for this ASAP, so this is what I've used for now. I've tested this manually and can confirm I can now use things despite installing in the system library folder.