### PR TITLE
Warning fixes

### DIFF
--- a/biomassrecovery/data/gedi_database.py
+++ b/biomassrecovery/data/gedi_database.py
@@ -193,7 +193,7 @@ class GediDatabase(object):
                             f"`{operator}` not allowed. Must be one of {COLUMN_OPERATORS}"
                         )
                     sql_column_operator_used = True
-                if (column not in self.allowed_cols[table_name]) and (column is not "*"):
+                if (column not in self.allowed_cols[table_name]) and (column != "*"):
                     raise ValueError(
                         f"`{column}` not allowed. Must be one of {sorted(list(self.allowed_cols[table_name]))} or `*`"
                     )

--- a/biomassrecovery/data/gedi_database.py
+++ b/biomassrecovery/data/gedi_database.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pyproj
 import sqlalchemy as db
 from sqlalchemy import create_engine, inspect
+from geoalchemy2 import Geometry # required to prevent warnings on column types
 
 from biomassrecovery.constants import WGS84
 from biomassrecovery.environment import DB_CONFIG


### PR DESCRIPTION
Two fixes, one minor, and one major:

* Major: SQLAlchemy is now failing for us due to more complaints about not recognising the geometry column type when processing data returned by PostGIS. Amelia spotted that if you import the Geometry type from GeoAlchemy that fixes it.
* Minor: Python was warning that we had a "is no" where we should be using a "!=", so I fixed that too.